### PR TITLE
Fix #39 by porting colonel to 1.19

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,8 +85,6 @@ dependencies {
   include(libs.examination.string)
   modCompileOnly(libs.jetbrainsAnnotations)
 
-  // modImplementation(libs.colonel)
-
   minecraft(libs.minecraft)
   mappings(loom.layered {
     officialMojangMappings()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ adventure-textMinimessage = { module = "net.kyori:adventure-text-minimessage", v
 adventure-textSerializerPlain = { module = "net.kyori:adventure-text-serializer-plain", version.ref = "adventure" }
 adventure-textSerializerGson = { module = "net.kyori:adventure-text-serializer-gson", version.ref = "adventure" }
 
-colonel = "ca.stellardrift:colonel:0.2.2"
 examination-api = { module = "net.kyori:examination-api", version.ref = "examination" }
 examination-string = { module = "net.kyori:examination-string", version.ref = "examination" }
 fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabricLoader"}

--- a/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/RequiredArgumentBuilderAccess.java
+++ b/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/RequiredArgumentBuilderAccess.java
@@ -21,34 +21,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.platform.fabric.impl.server;
+package net.kyori.adventure.platform.fabric.impl.accessor;
 
-import java.util.Set;
-import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.Nullable;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
 
-public interface ServerPlayerBridge {
-  /**
-   * Update the tab list header and footer.
-   *
-   * @param header header, null to leave unchanged
-   * @param footer footer, null to leave unchanged
-   * @since 4.0.0
-   */
-  void bridge$updateTabList(final @Nullable Component header, final @Nullable Component footer);
+@Mixin(value = RequiredArgumentBuilder.class, remap = false)
+public interface RequiredArgumentBuilderAccess {
 
-  /**
-   * Set of registered optional argument types.
-   *
-   * @return immutable set of type identifiers
-   */
-  Set<ResourceLocation> bridge$knownArguments();
-
-  /**
-   * Set the set of registered optional argument types.
-   *
-   * @param arguments set of type identifiers
-   */
-  void bridge$knownArguments(final Set<ResourceLocation> arguments);
+  @Accessor("type")
+  @Mutable
+  void accessor$type(final ArgumentType<?> type);
 }

--- a/src/accessor/resources/adventure-platform-fabric.accessor.mixins.json
+++ b/src/accessor/resources/adventure-platform-fabric.accessor.mixins.json
@@ -3,10 +3,10 @@
   "package": "net.kyori.adventure.platform.fabric.impl.accessor",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "ArgumentTypeInfosAccess",
     "ComponentSerializerAccess",
     "ConnectionAccess",
     "InvalidKeyExceptionAccess",
-    "LevelAccess"
+    "LevelAccess",
+    "RequiredArgumentBuilderAccess"
   ]
 }

--- a/src/client/java/net/kyori/adventure/platform/fabric/impl/client/AdventureClient.java
+++ b/src/client/java/net/kyori/adventure/platform/fabric/impl/client/AdventureClient.java
@@ -25,10 +25,12 @@ package net.kyori.adventure.platform.fabric.impl.client;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
 import net.kyori.adventure.platform.fabric.impl.AdventureCommon;
-import net.kyori.adventure.platform.fabric.impl.ClientboundRegisteredArgumentTypesPacket;
+import net.kyori.adventure.platform.fabric.impl.ClientboundArgumentTypeMappingsPacket;
 import net.kyori.adventure.platform.fabric.impl.ServerArgumentTypes;
+import net.kyori.adventure.platform.fabric.impl.ServerboundRegisteredArgumentTypesPacket;
 
 public final class AdventureClient implements ClientModInitializer {
   @Override
@@ -40,9 +42,13 @@ public final class AdventureClient implements ClientModInitializer {
     // sync is optional, so fapi is not required
     if (FabricLoader.getInstance().isModLoaded(AdventureCommon.MOD_FAPI_NETWORKING)) {
       C2SPlayChannelEvents.REGISTER.register((handler, sender, client, channels) -> {
-        if (channels.contains(ClientboundRegisteredArgumentTypesPacket.ID)) {
-          client.execute(() -> ClientboundRegisteredArgumentTypesPacket.of(ServerArgumentTypes.ids()).sendTo(sender));
+        if (channels.contains(ServerboundRegisteredArgumentTypesPacket.ID)) {
+          client.execute(() -> ServerboundRegisteredArgumentTypesPacket.of(ServerArgumentTypes.ids()).sendTo(sender));
         }
+      });
+      ClientPlayNetworking.registerGlobalReceiver(ClientboundArgumentTypeMappingsPacket.ID, (client, handler, buffer, responder) -> {
+        final ClientboundArgumentTypeMappingsPacket pkt = ClientboundArgumentTypeMappingsPacket.from(buffer);
+        client.execute(() -> ServerArgumentTypes.receiveMappings(pkt));
       });
     }
   }

--- a/src/main/java/net/kyori/adventure/platform/fabric/ComponentArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/ComponentArgumentType.java
@@ -44,9 +44,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * An argument that takes JSON-format text.
  *
- * <p>At the moment, using this argument type will require this mod
- * <strong>both server- and clientside</strong>, unless the
- * <a href="https://gitlab.com/stellardrift/colonel">Colonel</a> mod is present on the server.</p>
+ * <p>For this argument type to fully function, adventure-platform-fabric must also be present on the client. Clients
+ * without the mod will receive fallback types existing in the base game.</p>
  *
  * @since 4.0.0
  */

--- a/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
@@ -34,6 +34,9 @@ import org.jetbrains.annotations.NotNull;
 /**
  * An argument that will be decoded as a Key.
  *
+ * <p>For this argument type to fully function, adventure-platform-fabric must also be present on the client. Clients
+ * without the mod will receive fallback types existing in the base game.</p>
+ *
  * @since 4.0.0
  */
 public final class KeyArgumentType implements ArgumentType<Key> {

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.platform.fabric.impl;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.logging.LogUtils;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,7 +42,6 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.platform.fabric.ComponentArgumentType;
 import net.kyori.adventure.platform.fabric.KeyArgumentType;
 import net.kyori.adventure.platform.fabric.PlayerLocales;
-import net.kyori.adventure.platform.fabric.impl.accessor.ArgumentTypeInfosAccess;
 import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudiencesImpl;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.pointer.Pointers;
@@ -51,8 +51,9 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.TranslationRegistry;
 import net.kyori.adventure.translation.Translator;
+import net.minecraft.commands.arguments.ComponentArgument;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.commands.synchronization.SingletonArgumentInfo;
-import net.minecraft.core.Registry;
 import net.minecraft.locale.Language;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -68,6 +69,7 @@ public class AdventureCommon implements ModInitializer {
 
   public static final ComponentFlattener FLATTENER;
   private static final Pattern LOCALIZATION_PATTERN = Pattern.compile("%(?:(\\d+)\\$)?s");
+  public static final String MOD_FAPI_NETWORKING = "fabric-networking-v0";
 
   static {
     final var sidedProxy = chooseSidedProxy();
@@ -155,39 +157,7 @@ public class AdventureCommon implements ModInitializer {
 
   @Override
   public void onInitialize() {
-    // Register custom argument types
-    if (FabricLoader.getInstance().isModLoaded("colonel")) { // we can do server-only arg types
-      /*ServerArgumentType.<ComponentArgumentType>builder(res("component"))
-        .type(ComponentArgumentType.class)
-        .serializer(new ComponentArgumentTypeSerializer())
-        .fallbackProvider(arg -> {
-          return switch (arg.format()) {
-            case JSON -> ComponentArgument.textComponent();
-            case MINIMESSAGE -> StringArgumentType.greedyString();
-          };
-        })
-        .fallbackSuggestions(null) // client text parsing is fine
-        .register();
-      ServerArgumentType.<KeyArgumentType>builder(res("key"))
-        .type(KeyArgumentType.class)
-        .serializer(new EmptyArgumentSerializer<>(KeyArgumentType::key))
-        .fallbackProvider(arg -> ResourceLocationArgument.id())
-        .fallbackSuggestions(null)
-        .register();*/
-    } else {
-      ArgumentTypeInfosAccess.adventure$invoke$register(
-        Registry.COMMAND_ARGUMENT_TYPE,
-        "adventure:component",
-        ComponentArgumentType.class,
-        new ComponentArgumentTypeSerializer()
-      );
-      ArgumentTypeInfosAccess.adventure$invoke$register(
-        Registry.COMMAND_ARGUMENT_TYPE,
-        "adventure:key",
-        KeyArgumentType.class,
-        SingletonArgumentInfo.contextFree(KeyArgumentType::key)
-      );
-    }
+    this.setupCustomArgumentTypes();
 
     PlayerLocales.CHANGED_EVENT.register((player, locale) -> {
       FabricServerAudiencesImpl.forEachInstance(instance -> {
@@ -211,6 +181,35 @@ public class AdventureCommon implements ModInitializer {
         });
       }
     }
+  }
+
+  private void setupCustomArgumentTypes() {
+    // sync is optional, so fapi is not required
+    if (FabricLoader.getInstance().isModLoaded(MOD_FAPI_NETWORKING)) {
+      ClientboundRegisteredArgumentTypesPacket.register();
+    }
+
+    ServerArgumentTypes.register(
+      new ServerArgumentType<>(
+        res("component"),
+        ComponentArgumentType.class,
+        ComponentArgumentTypeSerializer.INSTANCE,
+        arg -> switch (arg.format()) {
+          case JSON -> ComponentArgument.textComponent();
+          case MINIMESSAGE -> StringArgumentType.greedyString();
+        },
+        null
+      )
+    );
+    ServerArgumentTypes.register(
+      new ServerArgumentType<>(
+        res("key"),
+        KeyArgumentType.class,
+        SingletonArgumentInfo.contextFree(KeyArgumentType::key),
+        arg -> ResourceLocationArgument.id(),
+        null
+      )
+    );
   }
 
   public static Function<Pointered, Locale> localePartition() {

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
@@ -69,7 +69,7 @@ public class AdventureCommon implements ModInitializer {
 
   public static final ComponentFlattener FLATTENER;
   private static final Pattern LOCALIZATION_PATTERN = Pattern.compile("%(?:(\\d+)\\$)?s");
-  public static final String MOD_FAPI_NETWORKING = "fabric-networking-v0";
+  public static final String MOD_FAPI_NETWORKING = "fabric-networking-api-v1";
 
   static {
     final var sidedProxy = chooseSidedProxy();
@@ -186,7 +186,7 @@ public class AdventureCommon implements ModInitializer {
   private void setupCustomArgumentTypes() {
     // sync is optional, so fapi is not required
     if (FabricLoader.getInstance().isModLoaded(MOD_FAPI_NETWORKING)) {
-      ClientboundRegisteredArgumentTypesPacket.register();
+      ServerboundRegisteredArgumentTypesPacket.register();
     }
 
     ServerArgumentTypes.register(

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundArgumentTypeMappingsPacket.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundArgumentTypeMappingsPacket.java
@@ -32,7 +32,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 
 public record ClientboundArgumentTypeMappingsPacket(Int2ObjectMap<ResourceLocation> mappings) {
-  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered-arg-mappings");
+  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered_arg_mappings");
 
   public static ClientboundArgumentTypeMappingsPacket from(final FriendlyByteBuf buffer) {
     final Int2ObjectMap<ResourceLocation> map = buffer.readMap(

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundArgumentTypeMappingsPacket.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundArgumentTypeMappingsPacket.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl;
+
+import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.kyori.adventure.Adventure;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
+public record ClientboundArgumentTypeMappingsPacket(Int2ObjectMap<ResourceLocation> mappings) {
+  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered-arg-mappings");
+
+  public static ClientboundArgumentTypeMappingsPacket from(final FriendlyByteBuf buffer) {
+    final Int2ObjectMap<ResourceLocation> map = buffer.readMap(
+      Int2ObjectArrayMap::new,
+      FriendlyByteBuf::readVarInt,
+      FriendlyByteBuf::readResourceLocation
+    );
+    return new ClientboundArgumentTypeMappingsPacket(map);
+  }
+
+  private FriendlyByteBuf serialize() {
+    final FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+    buf.writeMap(
+      this.mappings,
+      FriendlyByteBuf::writeVarInt,
+      FriendlyByteBuf::writeResourceLocation
+    );
+    return buf;
+  }
+
+  public void sendTo(final PacketSender responder) {
+    responder.sendPacket(ID, this.serialize());
+  }
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundRegisteredArgumentTypesPacket.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ClientboundRegisteredArgumentTypesPacket.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl;
+
+import io.netty.buffer.Unpooled;
+import java.util.HashSet;
+import java.util.Set;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.kyori.adventure.Adventure;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A packet sent client to server, to let the server know which optional argument types are available on the server.
+ *
+ * <p>This packet is sent by players on join, before the command tree is sent to the client.</p>
+ *
+ * @param known Known argument type ids
+ */
+public record ClientboundRegisteredArgumentTypesPacket(Set<ResourceLocation> known) {
+  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered-args");
+
+  public static void register() {
+    ServerPlayNetworking.registerGlobalReceiver(ID, (server, player, handler, buffer, responder) -> {
+      final ClientboundRegisteredArgumentTypesPacket pkt = ClientboundRegisteredArgumentTypesPacket.of(buffer);
+      server.execute(() -> { // on main thread
+        ServerArgumentTypes.knownArgumentTypes(player, pkt.known);
+      });
+    });
+  }
+
+  public static ClientboundRegisteredArgumentTypesPacket of(final Set<ResourceLocation> idents) {
+    return new ClientboundRegisteredArgumentTypesPacket(Set.copyOf(idents));
+  }
+
+  public static ClientboundRegisteredArgumentTypesPacket of(final @NonNull FriendlyByteBuf buf) {
+    final int length = buf.readVarInt();
+    final Set<ResourceLocation> items = new HashSet<>();
+    for (int i = 0; i < length; ++i) {
+      items.add(buf.readResourceLocation());
+    }
+    return of(items);
+  }
+
+  private void toPacket(final FriendlyByteBuf buffer) {
+    buffer.writeVarInt(this.known.size());
+    for (final ResourceLocation id : this.known) {
+      buffer.writeResourceLocation(id);
+    }
+  }
+
+  /**
+   * Send the client's list of identifiers to the server.
+   */
+  public void sendTo(final PacketSender sender) {
+    if (ClientPlayNetworking.canSend(ID)) {
+      final FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer(this.known.size() * 8));
+      this.toPacket(buffer);
+      sender.sendPacket(ID, buffer);
+    }
+  }
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ComponentArgumentTypeSerializer.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ComponentArgumentTypeSerializer.java
@@ -35,6 +35,9 @@ public final class ComponentArgumentTypeSerializer implements ArgumentTypeInfo<C
 
   public static ComponentArgumentTypeSerializer INSTANCE = new ComponentArgumentTypeSerializer();
 
+  private ComponentArgumentTypeSerializer() {
+  }
+
   @Override
   public void serializeToNetwork(final Template type, final FriendlyByteBuf buffer) {
     buffer.writeResourceLocation(FabricAudiences.toNative(type.format.id()));

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerArgumentType.java
@@ -21,34 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.platform.fabric.impl.server;
+package net.kyori.adventure.platform.fabric.impl;
 
-import java.util.Set;
-import net.minecraft.network.chat.Component;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import java.util.function.Function;
+import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.Nullable;
 
-public interface ServerPlayerBridge {
-  /**
-   * Update the tab list header and footer.
-   *
-   * @param header header, null to leave unchanged
-   * @param footer footer, null to leave unchanged
-   * @since 4.0.0
-   */
-  void bridge$updateTabList(final @Nullable Component header, final @Nullable Component footer);
-
-  /**
-   * Set of registered optional argument types.
-   *
-   * @return immutable set of type identifiers
-   */
-  Set<ResourceLocation> bridge$knownArguments();
-
-  /**
-   * Set the set of registered optional argument types.
-   *
-   * @param arguments set of type identifiers
-   */
-  void bridge$knownArguments(final Set<ResourceLocation> arguments);
+/**
+ * An argument type that only needs to be known on the server.
+ *
+ * @param id argument id
+ * @param type argument type
+ * @param argumentTypeInfo argument type info
+ * @param fallbackProvider fallback type provider
+ * @param fallbackSuggestions fallback suggestions provider
+ * @param <T> argument type
+ */
+public record ServerArgumentType<T extends ArgumentType<?>>(
+  ResourceLocation id,
+  Class<? super T> type,
+  ArgumentTypeInfo<T, ? extends ArgumentTypeInfo.Template<T>> argumentTypeInfo,
+  Function<T, ArgumentType<?>> fallbackProvider,
+  SuggestionProvider<?> fallbackSuggestions
+) {
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerArgumentTypes.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerArgumentTypes.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.kyori.adventure.platform.fabric.impl.server.ServerPlayerBridge;
+import net.minecraft.Util;
+import net.minecraft.commands.synchronization.ArgumentTypeInfo;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ServerArgumentTypes {
+  private static final Map<Class<?>, ServerArgumentType<?>> BY_TYPE = new HashMap<>();
+  private static final Map<ResourceLocation, ServerArgumentType<?>> BY_LOCATION = new ConcurrentHashMap<>();
+  private static final Int2ObjectMap<ServerArgumentType<?>> BY_ID = new Int2ObjectArrayMap<>();
+  private static final Object2IntMap<ArgumentTypeInfo<?, ?>> IDS_BY_TYPE_INFO = new Object2IntOpenCustomHashMap<>(Util.identityStrategy());
+  private static final AtomicInteger ID_COUNTER = new AtomicInteger(100000); // start at 100,000. hopefully nobody registers that many types.
+
+  @SuppressWarnings("unchecked")
+  public static <T extends ArgumentType<?>> ServerArgumentType<T> byClass(final Class<T> clazz) {
+    return (ServerArgumentType<T>) BY_TYPE.get(requireNonNull(clazz, "clazz"));
+  }
+
+  private ServerArgumentTypes() {
+  }
+
+  public static void register(final ServerArgumentType<?> type) {
+    final int id = ID_COUNTER.getAndIncrement();
+    BY_ID.put(id, type);
+    IDS_BY_TYPE_INFO.put(type.argumentTypeInfo(), id);
+    BY_TYPE.put(type.type(), type);
+    BY_LOCATION.put(type.id(), type);
+  }
+
+  public static Set<ResourceLocation> ids() {
+    return Collections.unmodifiableSet(BY_LOCATION.keySet());
+  }
+
+  public static boolean isServerType(final ArgumentTypeInfo<?, ?> argumentTypeInfo) {
+    return IDS_BY_TYPE_INFO.containsKey(argumentTypeInfo);
+  }
+
+  public static boolean hasId(final int id) {
+    return BY_ID.containsKey(id);
+  }
+
+  public static ServerArgumentType<?> byId(final int id) {
+    return BY_ID.get(id);
+  }
+
+  public static ServerArgumentType<?> serverType(final ArgumentTypeInfo<?, ?> argumentTypeInfo) {
+    return byId(IDS_BY_TYPE_INFO.getInt(argumentTypeInfo));
+  }
+
+  public static int id(final ArgumentTypeInfo<?, ?> argumentTypeInfo) {
+    return IDS_BY_TYPE_INFO.getInt(argumentTypeInfo);
+  }
+
+  public static void knownArgumentTypes(final ServerPlayer player, final Set<ResourceLocation> ids) {
+    ((ServerPlayerBridge) player).bridge$knownArguments(ids);
+    if (!ids.isEmpty()) { // TODO: Avoid resending the whole command tree, find a way to receive the packet before sending?
+      player.server.getCommands().sendCommands(player);
+    }
+  }
+
+  public static Set<ResourceLocation> knownArgumentTypes(final ServerPlayer player) {
+    return ((ServerPlayerBridge) player).bridge$knownArguments();
+  }
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerboundRegisteredArgumentTypesPacket.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerboundRegisteredArgumentTypesPacket.java
@@ -42,7 +42,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * @param known Known argument type ids
  */
 public record ServerboundRegisteredArgumentTypesPacket(Set<ResourceLocation> known) {
-  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered-args");
+  public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered_args");
 
   public static void register() {
     ServerPlayNetworking.registerGlobalReceiver(ID, (server, player, handler, buffer, responder) -> {

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerboundRegisteredArgumentTypesPacket.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/ServerboundRegisteredArgumentTypesPacket.java
@@ -41,23 +41,23 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * @param known Known argument type ids
  */
-public record ClientboundRegisteredArgumentTypesPacket(Set<ResourceLocation> known) {
+public record ServerboundRegisteredArgumentTypesPacket(Set<ResourceLocation> known) {
   public static final ResourceLocation ID = new ResourceLocation(Adventure.NAMESPACE, "registered-args");
 
   public static void register() {
     ServerPlayNetworking.registerGlobalReceiver(ID, (server, player, handler, buffer, responder) -> {
-      final ClientboundRegisteredArgumentTypesPacket pkt = ClientboundRegisteredArgumentTypesPacket.of(buffer);
+      final ServerboundRegisteredArgumentTypesPacket pkt = ServerboundRegisteredArgumentTypesPacket.of(buffer);
       server.execute(() -> { // on main thread
-        ServerArgumentTypes.knownArgumentTypes(player, pkt.known);
+        ServerArgumentTypes.knownArgumentTypes(player, pkt.known, responder);
       });
     });
   }
 
-  public static ClientboundRegisteredArgumentTypesPacket of(final Set<ResourceLocation> idents) {
-    return new ClientboundRegisteredArgumentTypesPacket(Set.copyOf(idents));
+  public static ServerboundRegisteredArgumentTypesPacket of(final Set<ResourceLocation> idents) {
+    return new ServerboundRegisteredArgumentTypesPacket(Set.copyOf(idents));
   }
 
-  public static ClientboundRegisteredArgumentTypesPacket of(final @NonNull FriendlyByteBuf buf) {
+  public static ServerboundRegisteredArgumentTypesPacket of(final @NonNull FriendlyByteBuf buf) {
     final int length = buf.readVarInt();
     final Set<ResourceLocation> items = new HashSet<>();
     for (int i = 0; i < length; ++i) {

--- a/src/main/resource-templates/fabric.mod.yaml
+++ b/src/main/resource-templates/fabric.mod.yaml
@@ -12,6 +12,8 @@ license: "MIT"
 entrypoints:
   main:
     - "net.kyori.adventure.platform.fabric.impl.AdventureCommon"
+  client:
+    - "net.kyori.adventure.platform.fabric.impl.client.AdventureClient"
   preLaunch:
     - "net.kyori.adventure.platform.fabric.impl.AdventurePrelaunch"
   adventure-internal:sidedproxy/client:
@@ -42,5 +44,3 @@ custom:
 depends:
   fabricloader: ">=0.4.0"
   fabric-api-base: "*"
-suggests:
-  colonel: ">=0.1"

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandsMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandsMixin.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl.mixin;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.tree.CommandNode;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import net.kyori.adventure.platform.fabric.impl.ServerArgumentType;
+import net.kyori.adventure.platform.fabric.impl.ServerArgumentTypes;
+import net.kyori.adventure.platform.fabric.impl.accessor.RequiredArgumentBuilderAccess;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(Commands.class)
+public abstract class CommandsMixin {
+
+  @SuppressWarnings({"rawtypes", "unchecked"}) // argument type generics
+  @Inject(
+    method = "fillUsableCommands",
+    locals = LocalCapture.CAPTURE_FAILEXCEPTION,
+    at = @At(value = "INVOKE", target = "com.mojang.brigadier.builder.RequiredArgumentBuilder.getSuggestionsProvider()Lcom/mojang/brigadier/suggestion/SuggestionProvider;", remap = false, ordinal = 0)
+  /*slice = @Slice(from = @At(value = "INVOKE_ASSIGN", target = "RequiredArgumentBuilder.executes(Lcom/mojang/brigadier/Command;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false), to = @At(value = "INVOKE", target = "RequiredArgumentBuilder.getRedirect()Lcom/mojang/brigadier/tree/CommandNode;", remap = false))*/
+  )
+  public <T> void adventure$replaceArgumentType(
+    final CommandNode<CommandSourceStack> tree,
+    final CommandNode<SharedSuggestionProvider> result,
+    final CommandSourceStack source,
+    final Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> nodes,
+    final CallbackInfo ci,
+    final Iterator<?> it,
+    final CommandNode<CommandSourceStack> current,
+    final ArgumentBuilder<?, ?> unused,
+    final RequiredArgumentBuilder<?, T> builder
+  ) throws CommandSyntaxException {
+    ServerArgumentType<ArgumentType<T>> type = ServerArgumentTypes.byClass((Class) builder.getType().getClass());
+    final Set<ResourceLocation> knownExtraCommands = ServerArgumentTypes.knownArgumentTypes(source.getPlayer()); // throws an exception, we can ignore bc this is always a player
+    // If we have a replacement and the arg type isn't known to the client, change the argument type
+    // This is super un-typesafe, but as long as the returned CommandNode is only used for serialization we are fine.
+    // Repeat as long as a type is replaceable -- that way you can have a hierarchy of argument types.
+    while (type != null && !knownExtraCommands.contains(type.id())) {
+      ((RequiredArgumentBuilderAccess) builder).accessor$type(type.fallbackProvider().apply(builder.getType()));
+      if (type.fallbackSuggestions() != null) {
+        builder.suggests((SuggestionProvider) type.fallbackSuggestions());
+      }
+      type = ServerArgumentTypes.byClass((Class) builder.getType().getClass());
+    }
+
+  }
+}

--- a/src/mixin/resources/adventure-platform-fabric.mixins.json
+++ b/src/mixin/resources/adventure-platform-fabric.mixins.json
@@ -3,7 +3,12 @@
   "package": "net.kyori.adventure.platform.fabric.impl.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ArgumentNodeStubMixin",
+    "ArgumentTypeInfosMixin",
+    "ArgumentUtilsMixin",
+    "ClientboundCommandsPacketMixin",
     "ClientboundStatusResponsePacketMixin",
+    "CommandsMixin",
     "CommandSourceStackMixin",
     "CommandSyntaxExceptionMixin",
     "ComponentMixin",


### PR DESCRIPTION
Fixes #39 

Works around registry sync issues by not registering argument types with the registry, instead using our own IDs.